### PR TITLE
Fixed extended dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Where $FileExtension is the suffix of your file and $FileType is the name, all i
 
 ```vim
 autocmd BufNewFile,BufRead *.$FileExtension set filetype=$FileType
-autocmd BufNewFile,BufRead *.cpp set filetype='cpp'
+autocmd BufNewFile,BufRead *.foo set filetype='foobar'
 ```
 
 ## Adding your comment symbol to Mutineer
@@ -58,11 +58,13 @@ As of now, there are three global single global variables that is accessible for
 
 ```vim
 " For :Mutineer
-let g:MutineerCommentSymbolDictionaryPerLanguage['&filetype'] = '$commentSymbol'
-let g:MutineerCommentSymbolDictionaryPerLanguage['cpp'] = '//'
+let g:MutineerCommentSymbolDictionaryPerLanguageExtended = {}       " REQUIRED LINE TO INITIALISE DICTIONARY
+let g:MutineerCommentSymbolDictionaryPerLanguageExtended['&filetype'] = '$commentSymbol'
+let g:MutineerCommentSymbolDictionaryPerLanguageExtended['foobar'] = '@@'
 
+let g:MutineerCommentSymbolDictionaryPerLanguageExtended = {}       " REQUIRED LINE TO INITIALISE DICTIONARY
 let g:MutineerCommentSymbolDictionaryPerLanguageBLOCK['&filetype'] = ['$startCS', '$middleCS', '$endCS']
-let g:MutineerCommentSymbolDictionaryPerLanguageBLOCK['cpp'] = ['/*', '**', '*/']
+let g:MutineerCommentSymbolDictionaryPerLanguageBLOCK['foobar'] = ['/@', '**', '@/']
 ```
 with `$commentSymbol` (CS) the character that denotes a commented line in your preferred language.
 

--- a/autoload/utilities/mutineer_utilities.vim
+++ b/autoload/utilities/mutineer_utilities.vim
@@ -6,9 +6,25 @@ function! utilities#mutineer_utilities#RetrieveFileTypeForCommentSymbol(method) 
     let l:ft = &filetype
     " This variable is set in the plugin/mutineer.vim
     if a:method == "line"
-        return g:MutineerCommentSymbolDictionaryPerLanguage[l:ft]
+        if has_key(g:MutineerCommentSymbolDictionaryPerLanguage, l:ft)
+            return g:MutineerCommentSymbolDictionaryPerLanguage[l:ft]
+        elseif !empty(g:MutineerCommentSymbolDictionaryPerLanguageExtended)
+            if has_key(g:MutineerCommentSymbolDictionaryPerLanguageExtended, l:ft)
+                return g:MutineerCommentSymbolDictionaryPerLanguageExtended[l:ft]
+            endif
+        else
+            echoerr "E69 Key does not exist! Add your &filetype to g:MutineerCommentSymbolDictionaryPerLanguageExtended "
+        endif
     elseif a:method == "block"
-        return g:MutineerCommentSymbolDictionaryPerLanguageBLOCK[l:ft]
+        if has_key(g:MutineerCommentSymbolDictionaryPerLanguageBLOCK, l:ft)
+            return g:MutineerCommentSymbolDictionaryPerLanguageBLOCK[l:ft]
+        elseif !empty(g:MutineerCommentSymbolDictionaryPerLanguageBLOCKExtended)
+            if has_key(g:MutineerCommentSymbolDictionaryPerLanguageBLOCKExtended, l:ft)
+                return g:MutineerCommentSymbolDictionaryPerLanguageBLOCKExtended[l:ft]
+            endif
+        else
+            echoerr "E69 Key does not exist! Add your &filetype to g:MutineerCommentSymbolDictionaryPerLanguageBLOCKExtended "
+        endif
     endif
 endfunction
 
@@ -59,6 +75,7 @@ function! utilities#mutineer_utilities#SingleLine(commentStr, linenr) abort
     " Check if the line has been commented before with a $commentSymbol(s)
     let l:FirstChar = utilities#mutineer_utilities#FirstCharactersOfLine(a:commentStr, a:linenr)
     
+    echom l:FirstChar
     if a:commentStr !=? FirstChar " not equal, case insensitive
         call utilities#mutineer_utilities#CommentALine(a:commentStr, FirstChar, a:linenr) 
         if g:SpasticCursorMovementToggle

--- a/autoload/utilities/mutineer_utilities.vim
+++ b/autoload/utilities/mutineer_utilities.vim
@@ -75,7 +75,6 @@ function! utilities#mutineer_utilities#SingleLine(commentStr, linenr) abort
     " Check if the line has been commented before with a $commentSymbol(s)
     let l:FirstChar = utilities#mutineer_utilities#FirstCharactersOfLine(a:commentStr, a:linenr)
     
-    echom l:FirstChar
     if a:commentStr !=? FirstChar " not equal, case insensitive
         call utilities#mutineer_utilities#CommentALine(a:commentStr, FirstChar, a:linenr) 
         if g:SpasticCursorMovementToggle


### PR DESCRIPTION
Fixed where you could not add your own Comment Symbols to Mutineer.

This was because you cannot add keys to a dictionary from the plugin file.
Now you have to initialise a second dictionary in case you want to have a new comment symbol for a certain filetype